### PR TITLE
Fix to cost of Lawmaster

### DIFF
--- a/Judge_Dredd_Miniatures_Game_(WG2019).gst
+++ b/Judge_Dredd_Miniatures_Game_(WG2019).gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ae68-bf10-140a-0058" name="Judge Dredd Miniatures Game (WG2019)" revision="6" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ae68-bf10-140a-0058" name="Judge Dredd Miniatures Game (WG2019)" revision="7" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="23e2-8cf2-260a-a7be" name="JDMG (2019)"/>
     <publication id="4353-a3c6-7b4d-0185" name="BW (2023)"/>
@@ -1941,7 +1941,7 @@
             <entryLink id="2790-c49a-cbb9-45e4" name="[Lawmaster Weapons" hidden="false" collective="false" import="true" targetId="759f-e645-6e4f-17de" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" Notoriety" typeId="c427-d435-2985-7283" value="0.0"/>
+            <cost name=" Notoriety" typeId="c427-d435-2985-7283" value="5.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>


### PR DESCRIPTION
Lawmaster without weapons now properly costs 5 notoriety.